### PR TITLE
Add risk-reward filters and signal capping to ML backtest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
 # GPT
+
+## BATS_CSCO Dataset Inspection
+
+Run the helper script to inspect the dataset and produce summary statistics:
+
+```bash
+python analyze_bats_csco.py
+```
+
+To export the summary as JSON, provide the `--json` flag:
+
+```bash
+python analyze_bats_csco.py --json report.json
+```
+
+## Renko Brick Size Optimizer
+
+Evaluate Renko brick sizes for the 5-minute closing dataset:
+
+```bash
+python renko_brick_optimizer.py --data 'BATS_CSCO, 5.csv'
+```
+
+Customize the search range by supplying `--min-brick`, `--max-brick`, and the
+number of `--steps` to sample within that range. Display additional candidate
+results with the `--top` flag.
+
+## Supertrend Backtest
+
+Run a Supertrend crossover backtest (default parameters: period 10, multiplier
+1.5, starting capital $1,000):
+
+```bash
+python supertrend_backtest.py --data 'BATS_CSCO, 5.csv'
+```
+
+Override the Supertrend configuration or capital by providing the `--period`,
+`--multiplier`, or `--capital` flags.
+
+## Machine Learning Pattern Discovery
+
+Mine directional edges with an indicator-rich neural network that learns from
+OHLC momentum, MACD, RSI, ATR, stochastic oscillators, and volatility regimes:
+
+```bash
+python machine_learning_patterns.py --data 'BATS_CSCO, 5.csv'
+```
+
+Tune the workflow with `--train-ratio`, `--learning-rate`, `--epochs`,
+`--hidden-units`, `--batch-size`, `--patience`, `--min-delta`, `--train-window`,
+or `--l2` to adjust the optimization schedule, sample window, early-stopping
+tolerance, and regularization. Control signal selectivity via
+`--signal-threshold` (probability required before opening a trade) and
+`--top-signals` to cap execution to the highest-confidence setups.
+
+The report now scans multi-bar trades launched on bullish signals across a
+stop-loss / take-profit / trailing-stop grid, surfacing the richest scenario on
+the held-out set. Adjust the evaluation grid with `--stop-losses`,
+`--take-profits`, `--trailing-stops`, and the bankroll with `--capital`.
+Enforce a minimum win rate using `--min-win-rate`, and require a specific
+risk/reward profile (for example, `--risk-reward 2 --ratio-tolerance 0.05` for
+1:2 trades) to filter the presented scenarios.

--- a/analyze_bats_csco.py
+++ b/analyze_bats_csco.py
@@ -1,0 +1,162 @@
+"""Utility to inspect the `BATS_CSCO, 5.csv` dataset.
+
+The script provides:
+- Basic metadata (row count, column names, time span)
+- Summary statistics for OHLC columns
+- Counts of NaN values per column
+
+Usage::
+
+    python analyze_bats_csco.py
+
+The script prints results to stdout. It can optionally save a JSON report using
+`--json <path>`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from math import sqrt
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+DATA_FILE = Path("BATS_CSCO, 5.csv")
+OHLC_COLUMNS = ("open", "high", "low", "close")
+
+
+@dataclass
+class DatasetSummary:
+    rows: int
+    columns: int
+    start_time: str
+    end_time: str
+    column_names: List[str]
+    nan_counts: Dict[str, int]
+    ohlc_summary: Dict[str, Dict[str, float]]
+
+
+def load_dataset(path: Path) -> Tuple[List[str], List[Dict[str, str]]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset not found: {path}")
+
+    with path.open("r", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        rows = list(reader)
+    return reader.fieldnames or [], rows
+
+
+def parse_time(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def summarize_dataset(columns: List[str], rows: List[Dict[str, str]]) -> DatasetSummary:
+    if not rows:
+        raise ValueError("Dataset is empty")
+
+    start_time = parse_time(rows[0]["time"])
+    end_time = parse_time(rows[-1]["time"])
+
+    nan_counts = {col: 0 for col in columns}
+    ohlc_values = {col: [] for col in OHLC_COLUMNS}
+
+    for row in rows:
+        for col in columns:
+            if row[col] in {"", "NaN", "nan"}:
+                nan_counts[col] += 1
+
+        for col in OHLC_COLUMNS:
+            value = row[col]
+            if value not in {"", "NaN", "nan"}:
+                ohlc_values[col].append(float(value))
+
+    ohlc_summary = {
+        col: compute_summary(values)
+        for col, values in ohlc_values.items()
+    }
+
+    return DatasetSummary(
+        rows=len(rows),
+        columns=len(columns),
+        start_time=start_time.isoformat(),
+        end_time=end_time.isoformat(),
+        column_names=columns,
+        nan_counts=nan_counts,
+        ohlc_summary=ohlc_summary,
+    )
+
+
+def compute_summary(values: Iterable[float]) -> Dict[str, float]:
+    values = list(values)
+    if not values:
+        return {key: float("nan") for key in ("min", "max", "mean", "std")}
+
+    total = sum(values)
+    mean = total / len(values)
+    variance = sum((value - mean) ** 2 for value in values) / len(values)
+    return {
+        "min": min(values),
+        "max": max(values),
+        "mean": mean,
+        "std": sqrt(variance),
+    }
+
+
+def format_summary(summary: DatasetSummary) -> str:
+    lines = [
+        "BATS_CSCO dataset summary",
+        "-------------------------",
+        f"Rows: {summary.rows}",
+        f"Columns: {summary.columns}",
+        f"Time span: {summary.start_time} -> {summary.end_time}",
+        "",
+        "Columns:",
+    ]
+    lines.extend(f"  - {name}" for name in summary.column_names)
+    lines.append("")
+    lines.append("NaN counts:")
+    lines.extend(f"  - {col}: {count}" for col, count in summary.nan_counts.items())
+    lines.append("")
+    lines.append("OHLC summary statistics:")
+    for col, stats in summary.ohlc_summary.items():
+        stats_str = ", ".join(f"{key}={value:.6f}" for key, value in stats.items())
+        lines.append(f"  - {col}: {stats_str}")
+    return "\n".join(lines)
+
+
+def write_json(summary: DatasetSummary, path: Path) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(asdict(summary), fh, indent=2)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        type=Path,
+        help="Optional path to save the summary as JSON.",
+    )
+    parser.add_argument(
+        "--data",
+        type=Path,
+        default=DATA_FILE,
+        help="Path to the CSV dataset (default: BATS_CSCO, 5.csv)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    columns, rows = load_dataset(args.data)
+    summary = summarize_dataset(columns, rows)
+    print(format_summary(summary))
+    if args.json:
+        write_json(summary, args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/machine_learning_patterns.py
+++ b/machine_learning_patterns.py
@@ -1,0 +1,1188 @@
+"""Discover higher-order directional patterns in the CSCO 5-minute dataset using
+an indicator-rich neural network pipeline.
+
+The workflow engineers classic technical indicators (EMA gaps, MACD histogram,
+RSI, ATR, and stochastic oscillators) alongside OHLC-derived momentum and
+volatility signals. A single-hidden-layer neural network is then trained via
+mini-batch gradient descent to predict whether the next bar will close above the
+current bar. The script surfaces evaluation metrics, key feature influences, and
+scans multi-bar trades driven by bullish signals across configurable stop-loss,
+profit-target, and trailing-stop grids to locate the most profitable mix.
+
+Usage (default dataset):
+
+    python machine_learning_patterns.py
+
+Command-line flags allow you to override the dataset path, train/test split,
+optimizer hyperparameters, network width, capital, and the stop/target/trailing
+grid. Inspect ``python machine_learning_patterns.py --help`` for the full set of
+options.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+def safe_value(value: float) -> float:
+    if math.isnan(value) or math.isinf(value):
+        return 0.0
+    return value
+
+
+DATA_FILE = Path("BATS_CSCO, 5.csv")
+
+
+@dataclass
+class Dataset:
+    features: List[List[float]]
+    targets: List[int]
+    feature_names: List[str]
+    entry_prices: List[float]
+    next_prices: List[float]
+    row_indices: List[int]
+    opens: List[float]
+    highs: List[float]
+    lows: List[float]
+    closes: List[float]
+
+
+@dataclass
+class Standardization:
+    means: List[float]
+    stds: List[float]
+
+
+@dataclass
+class NeuralNetwork:
+    w1: List[List[float]]
+    b1: List[float]
+    w2: List[float]
+    b2: float
+
+    def _forward_layer(self, features: Sequence[float]) -> Tuple[List[float], List[float]]:
+        pre_activations: List[float] = []
+        activations: List[float] = []
+        for h in range(len(self.b1)):
+            weighted_sum = sum(features[f] * self.w1[f][h] for f in range(len(features))) + self.b1[h]
+            pre_activations.append(weighted_sum)
+            activations.append(weighted_sum if weighted_sum > 0 else 0.0)
+        return pre_activations, activations
+
+    def predict_proba(self, features: Sequence[float]) -> float:
+        _, hidden = self._forward_layer(features)
+        logit = sum(hidden[h] * self.w2[h] for h in range(len(self.w2))) + self.b2
+        logit = max(min(logit, 60.0), -60.0)
+        return 1.0 / (1.0 + math.exp(-logit))
+
+    def predict_label(self, features: Sequence[float]) -> int:
+        return 1 if self.predict_proba(features) >= 0.5 else 0
+
+
+@dataclass
+class Evaluation:
+    accuracy: float
+    precision: float
+    recall: float
+    f1: float
+    true_positive: int
+    true_negative: int
+    false_positive: int
+    false_negative: int
+
+
+@dataclass
+class TrainingResult:
+    model: NeuralNetwork
+    standardization: Standardization
+    evaluation: Evaluation
+    train_count: int
+    full_train_count: int
+    test_count: int
+    test_probabilities: List[float]
+    test_predictions: List[int]
+    threshold: float
+    loss_history: List[float]
+
+
+@dataclass
+class TrainTestSplit:
+    train: Dataset
+    test: Dataset
+
+
+@dataclass
+class BacktestReport:
+    starting_cash: float
+    ending_value: float
+    trades: int
+    wins: int
+    losses: int
+    win_rate: float
+    win_loss_ratio: float | None
+    profit: float
+    return_pct: float
+    average_bars_held: float
+    max_bars_held: int
+    stop_loss_pct: float | None
+    take_profit_pct: float | None
+    trailing_stop_pct: float | None
+
+
+def load_dataset(path: Path) -> List[dict]:
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset not found: {path}")
+
+    with path.open("r", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+    if not rows:
+        raise ValueError("Dataset is empty")
+    return rows
+
+
+def to_float(value: str) -> float:
+    if value in {"", "NaN", "nan", "None"}:
+        return float("nan")
+    return float(value)
+
+
+def compute_log_return(new: float, old: float) -> float:
+    if new <= 0 or old <= 0:
+        return 0.0
+    return math.log(new / old)
+
+
+def rolling_std(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    mean = sum(values) / len(values)
+    variance = sum((value - mean) ** 2 for value in values) / len(values)
+    return math.sqrt(variance)
+
+
+def ema(values: Sequence[float], period: int) -> List[float]:
+    if period <= 0:
+        raise ValueError("EMA period must be positive")
+    ema_values = [float("nan")] * len(values)
+    multiplier = 2.0 / (period + 1)
+    ema_prev: float | None = None
+    for idx, value in enumerate(values):
+        if math.isnan(value):
+            ema_values[idx] = ema_prev if ema_prev is not None else float("nan")
+            continue
+        if ema_prev is None:
+            ema_prev = value
+        else:
+            ema_prev = (value - ema_prev) * multiplier + ema_prev
+        ema_values[idx] = ema_prev
+    return ema_values
+
+
+def compute_macd(values: Sequence[float]) -> Tuple[List[float], List[float], List[float]]:
+    ema_fast = ema(values, 12)
+    ema_slow = ema(values, 26)
+    macd_line = []
+    for fast, slow in zip(ema_fast, ema_slow):
+        if math.isnan(fast) or math.isnan(slow):
+            macd_line.append(float("nan"))
+        else:
+            macd_line.append(fast - slow)
+    signal_line = ema(macd_line, 9)
+    histogram = []
+    for macd_value, signal_value in zip(macd_line, signal_line):
+        if math.isnan(macd_value) or math.isnan(signal_value):
+            histogram.append(float("nan"))
+        else:
+            histogram.append(macd_value - signal_value)
+    return ema_fast, ema_slow, histogram
+
+
+def compute_rsi(closes: Sequence[float], period: int = 14) -> List[float]:
+    rsi_values = [float("nan")] * len(closes)
+    avg_gain = avg_loss = 0.0
+    gain_count = loss_count = 0
+    for idx in range(1, len(closes)):
+        change = closes[idx] - closes[idx - 1]
+        gain = max(change, 0.0)
+        loss = max(-change, 0.0)
+        avg_gain += gain
+        avg_loss += loss
+        gain_count += 1
+        loss_count += 1
+        if idx < period:
+            continue
+        if idx == period:
+            avg_gain /= period
+            avg_loss /= period
+        else:
+            avg_gain = ((period - 1) * avg_gain + gain) / period
+            avg_loss = ((period - 1) * avg_loss + loss) / period
+        if avg_loss == 0:
+            rsi = 100.0
+        else:
+            rs = avg_gain / avg_loss
+            rsi = 100.0 - (100.0 / (1.0 + rs))
+        rsi_values[idx] = rsi
+    return rsi_values
+
+
+def compute_atr(highs: Sequence[float], lows: Sequence[float], closes: Sequence[float], period: int = 14) -> List[float]:
+    atr_values = [float("nan")] * len(closes)
+    prev_close = closes[0] if closes else float("nan")
+    tr_values: List[float] = []
+    atr_prev: float | None = None
+    for idx in range(len(closes)):
+        high = highs[idx]
+        low = lows[idx]
+        close = closes[idx]
+        if math.isnan(high) or math.isnan(low) or math.isnan(close):
+            tr = 0.0
+        elif idx == 0 or math.isnan(prev_close):
+            tr = high - low
+        else:
+            tr = max(high - low, abs(high - prev_close), abs(low - prev_close))
+        tr_values.append(tr)
+        if idx < period:
+            prev_close = close
+            continue
+        if idx == period:
+            atr_prev = sum(tr_values[1:period + 1]) / period
+        elif atr_prev is not None:
+            atr_prev = ((period - 1) * atr_prev + tr) / period
+        atr = atr_prev if atr_prev is not None else 0.0
+        atr_values[idx] = atr
+        prev_close = close
+    return atr_values
+
+
+def compute_stochastic(highs: Sequence[float], lows: Sequence[float], closes: Sequence[float], period: int = 14, smooth: int = 3) -> Tuple[List[float], List[float]]:
+    k_values = [float("nan")] * len(closes)
+    d_values = [float("nan")] * len(closes)
+    for idx in range(len(closes)):
+        if idx < period - 1:
+            continue
+        window_high = max(highs[idx - period + 1 : idx + 1])
+        window_low = min(lows[idx - period + 1 : idx + 1])
+        denom = window_high - window_low
+        if denom <= 0:
+            k = 0.0
+        else:
+            k = (closes[idx] - window_low) / denom * 100.0
+        k_values[idx] = k
+        if idx >= period - 1 + smooth - 1:
+            recent_k = [value for value in k_values[idx - smooth + 1 : idx + 1] if not math.isnan(value)]
+            if recent_k:
+                d_values[idx] = sum(recent_k) / len(recent_k)
+            else:
+                d_values[idx] = 0.0
+    return k_values, d_values
+
+
+def build_features(rows: List[dict]) -> Dataset:
+    closes = [to_float(row["close"]) for row in rows]
+    opens = [to_float(row["open"]) for row in rows]
+    highs = [to_float(row["high"]) for row in rows]
+    lows = [to_float(row["low"]) for row in rows]
+
+    ema_fast, ema_slow, macd_hist = compute_macd(closes)
+    rsi_values = compute_rsi(closes, 14)
+    atr_values = compute_atr(highs, lows, closes, 14)
+    stoch_k, stoch_d = compute_stochastic(highs, lows, closes, 14, 3)
+
+    max_lag = 35
+    feature_names = [
+        "log_return_1",  # immediate momentum
+        "log_return_5",  # short-term momentum
+        "log_return_10",  # longer swing momentum
+        "body_pct",  # candle body as share of open
+        "range_pct",  # intrabar volatility
+        "volatility_5",  # rolling volatility over 5 bars
+        "volatility_14",  # extended volatility regime
+        "ema_fast_minus_slow",  # 12-26 EMA spread
+        "macd_histogram",  # MACD histogram
+        "rsi_14",  # RSI (0-1 scaled)
+        "atr_pct",  # ATR as share of price
+        "stoch_k",  # stochastic %K (0-1 scaled)
+        "stoch_d",  # stochastic %D (0-1 scaled)
+        "trend_vs_ema",  # close distance from slow EMA
+    ]
+
+    features: List[List[float]] = []
+    targets: List[int] = []
+    entry_prices: List[float] = []
+    next_prices: List[float] = []
+    row_indices: List[int] = []
+
+    log_returns: List[float] = [0.0]
+    for idx in range(1, len(closes)):
+        log_returns.append(compute_log_return(closes[idx], closes[idx - 1]))
+
+    for idx in range(max_lag, len(rows) - 1):
+        lr_1 = log_returns[idx]
+        lr_5 = compute_log_return(closes[idx], closes[idx - 5]) if idx >= 5 else 0.0
+        lr_10 = compute_log_return(closes[idx], closes[idx - 10]) if idx >= 10 else 0.0
+        body = closes[idx] - opens[idx]
+        body_pct = body / opens[idx] if opens[idx] else 0.0
+        range_pct = (highs[idx] - lows[idx]) / closes[idx] if closes[idx] else 0.0
+        window_5 = log_returns[idx - 4 : idx + 1]
+        window_14 = log_returns[idx - 13 : idx + 1]
+        vol_5 = rolling_std(window_5)
+        vol_14 = rolling_std(window_14)
+        ema_gap = ema_fast[idx] - ema_slow[idx]
+        macd_val = macd_hist[idx]
+        rsi_val = rsi_values[idx] / 100.0 if not math.isnan(rsi_values[idx]) else 0.0
+        atr_pct = (atr_values[idx] / closes[idx]) if closes[idx] and not math.isnan(atr_values[idx]) else 0.0
+        stoch_k_val = stoch_k[idx] / 100.0 if not math.isnan(stoch_k[idx]) else 0.0
+        stoch_d_val = stoch_d[idx] / 100.0 if not math.isnan(stoch_d[idx]) else 0.0
+        ema_slow_val = ema_slow[idx]
+        trend_vs_ema = ((closes[idx] - ema_slow_val) / closes[idx]) if closes[idx] and not math.isnan(ema_slow_val) else 0.0
+
+        feature_vector = [
+            safe_value(lr_1),
+            safe_value(lr_5),
+            safe_value(lr_10),
+            safe_value(body_pct),
+            safe_value(range_pct),
+            safe_value(vol_5),
+            safe_value(vol_14),
+            safe_value(ema_gap),
+            safe_value(macd_val),
+            safe_value(rsi_val),
+            safe_value(atr_pct),
+            safe_value(stoch_k_val),
+            safe_value(stoch_d_val),
+            safe_value(trend_vs_ema),
+        ]
+
+        features.append(feature_vector)
+        targets.append(1 if closes[idx + 1] > closes[idx] else 0)
+        entry_prices.append(closes[idx])
+        next_prices.append(closes[idx + 1])
+        row_indices.append(idx)
+
+    return Dataset(
+        features=features,
+        targets=targets,
+        feature_names=feature_names,
+        entry_prices=entry_prices,
+        next_prices=next_prices,
+        row_indices=row_indices,
+        opens=opens,
+        highs=highs,
+        lows=lows,
+        closes=closes,
+    )
+
+
+def split_dataset(dataset: Dataset, train_ratio: float) -> Tuple[Dataset, Dataset]:
+    total = len(dataset.features)
+    train_count = int(total * train_ratio)
+    train = Dataset(
+        features=dataset.features[:train_count],
+        targets=dataset.targets[:train_count],
+        feature_names=dataset.feature_names,
+        entry_prices=dataset.entry_prices[:train_count],
+        next_prices=dataset.next_prices[:train_count],
+        row_indices=dataset.row_indices[:train_count],
+        opens=dataset.opens,
+        highs=dataset.highs,
+        lows=dataset.lows,
+        closes=dataset.closes,
+    )
+    test = Dataset(
+        features=dataset.features[train_count:],
+        targets=dataset.targets[train_count:],
+        feature_names=dataset.feature_names,
+        entry_prices=dataset.entry_prices[train_count:],
+        next_prices=dataset.next_prices[train_count:],
+        row_indices=dataset.row_indices[train_count:],
+        opens=dataset.opens,
+        highs=dataset.highs,
+        lows=dataset.lows,
+        closes=dataset.closes,
+    )
+    if not train.features or not test.features:
+        raise ValueError("Training or test split ended up empty; adjust train_ratio")
+    return train, test
+
+
+def compute_standardization(features: Sequence[Sequence[float]]) -> Standardization:
+    num_features = len(features[0])
+    means: List[float] = []
+    stds: List[float] = []
+    for idx in range(num_features):
+        column = [row[idx] for row in features]
+        mean = sum(column) / len(column)
+        variance = sum((value - mean) ** 2 for value in column) / len(column)
+        std = math.sqrt(variance)
+        if std < 1e-12:
+            std = 1.0
+        means.append(mean)
+        stds.append(std)
+    return Standardization(means=means, stds=stds)
+
+
+def apply_standardization(features: Sequence[Sequence[float]], stats: Standardization) -> List[List[float]]:
+    scaled: List[List[float]] = []
+    for row in features:
+        scaled.append([(value - mean) / std for value, mean, std in zip(row, stats.means, stats.stds)])
+    return scaled
+
+
+def train_neural_network(
+    features: Sequence[Sequence[float]],
+    targets: Sequence[int],
+    *,
+    learning_rate: float,
+    epochs: int,
+    hidden_units: int,
+    batch_size: int,
+    l2: float = 0.0,
+    early_stop_patience: int = 0,
+    early_stop_delta: float = 1e-4,
+) -> Tuple[NeuralNetwork, List[float]]:
+    if not features:
+        raise ValueError("No training samples provided")
+    n_samples = len(features)
+    n_features = len(features[0])
+    rng = random.Random(42)
+
+    w1: List[List[float]] = [
+        [rng.gauss(0.0, 0.1) for _ in range(hidden_units)] for _ in range(n_features)
+    ]
+    b1: List[float] = [0.0 for _ in range(hidden_units)]
+    w2: List[float] = [rng.gauss(0.0, 0.1) for _ in range(hidden_units)]
+    b2 = 0.0
+
+    loss_history: List[float] = []
+    indices = list(range(n_samples))
+
+    for _ in range(epochs):
+        rng.shuffle(indices)
+        for start in range(0, n_samples, batch_size):
+            batch_indices = indices[start : start + batch_size]
+            if not batch_indices:
+                continue
+
+            grad_w1 = [[0.0 for _ in range(hidden_units)] for _ in range(n_features)]
+            grad_b1 = [0.0 for _ in range(hidden_units)]
+            grad_w2 = [0.0 for _ in range(hidden_units)]
+            grad_b2 = 0.0
+
+            for idx in batch_indices:
+                x = features[idx]
+                y = targets[idx]
+                z1 = [
+                    sum(x[f] * w1[f][h] for f in range(n_features)) + b1[h]
+                    for h in range(hidden_units)
+                ]
+                hidden = [value if value > 0 else 0.0 for value in z1]
+                logit = sum(hidden[h] * w2[h] for h in range(hidden_units)) + b2
+                logit = max(min(logit, 60.0), -60.0)
+                prob = 1.0 / (1.0 + math.exp(-logit))
+                error = prob - y
+
+                for h in range(hidden_units):
+                    grad_w2[h] += error * hidden[h]
+                grad_b2 += error
+
+                for h in range(hidden_units):
+                    grad = error * w2[h]
+                    if z1[h] <= 0:
+                        grad = 0.0
+                    grad_b1[h] += grad
+                    for f in range(n_features):
+                        grad_w1[f][h] += grad * x[f]
+
+            batch_len = len(batch_indices)
+            inv_batch = 1.0 / batch_len
+
+            for h in range(hidden_units):
+                grad_w2[h] = grad_w2[h] * inv_batch + (l2 * w2[h] if l2 else 0.0)
+            grad_b2 *= inv_batch
+
+            for f in range(n_features):
+                for h in range(hidden_units):
+                    grad = grad_w1[f][h] * inv_batch + (l2 * w1[f][h] if l2 else 0.0)
+                    w1[f][h] -= learning_rate * grad
+            for h in range(hidden_units):
+                grad = grad_b1[h] * inv_batch
+                b1[h] -= learning_rate * grad
+                w2[h] -= learning_rate * grad_w2[h]
+            b2 -= learning_rate * grad_b2
+
+        total_loss = 0.0
+        for idx in range(n_samples):
+            x = features[idx]
+            y = targets[idx]
+            z1 = [
+                sum(x[f] * w1[f][h] for f in range(n_features)) + b1[h]
+                for h in range(hidden_units)
+            ]
+            hidden = [value if value > 0 else 0.0 for value in z1]
+            logit = sum(hidden[h] * w2[h] for h in range(hidden_units)) + b2
+            logit = max(min(logit, 60.0), -60.0)
+            prob = 1.0 / (1.0 + math.exp(-logit))
+            eps = 1e-9
+            total_loss += -(y * math.log(prob + eps) + (1 - y) * math.log(1 - prob + eps))
+        total_loss /= n_samples
+        if l2:
+            total_loss += 0.5 * l2 * (
+                sum(weight * weight for row in w1 for weight in row)
+                + sum(weight * weight for weight in w2)
+            )
+        loss_history.append(total_loss)
+        if early_stop_patience and len(loss_history) >= early_stop_patience:
+            window = loss_history[-early_stop_patience:]
+            if max(window) - min(window) < early_stop_delta:
+                break
+
+    model = NeuralNetwork(w1=w1, b1=b1, w2=w2, b2=b2)
+    return model, loss_history
+
+
+def evaluate_model(
+    model: NeuralNetwork,
+    features: Sequence[Sequence[float]],
+    targets: Sequence[int],
+    threshold: float = 0.5,
+) -> Evaluation:
+    tp = tn = fp = fn = 0
+    for row, target in zip(features, targets):
+        prob = model.predict_proba(row)
+        pred = 1 if prob >= threshold else 0
+        if pred == 1 and target == 1:
+            tp += 1
+        elif pred == 0 and target == 0:
+            tn += 1
+        elif pred == 1 and target == 0:
+            fp += 1
+        else:
+            fn += 1
+
+    total = tp + tn + fp + fn
+    accuracy = (tp + tn) / total if total else 0.0
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+
+    return Evaluation(
+        accuracy=accuracy,
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        true_positive=tp,
+        true_negative=tn,
+        false_positive=fp,
+        false_negative=fn,
+    )
+
+
+def simulate_trade_exit(
+    closes: Sequence[float],
+    highs: Sequence[float],
+    lows: Sequence[float],
+    entry_index: int,
+    stop_loss_pct: float | None,
+    take_profit_pct: float | None,
+    trailing_stop_pct: float | None,
+) -> Tuple[float, int, int, str]:
+    entry_price = closes[entry_index]
+    if math.isnan(entry_price) or entry_price <= 0:
+        return entry_price if entry_price > 0 else 0.0, entry_index, 0, "invalid"
+
+    stop_price = entry_price * (1 - stop_loss_pct) if stop_loss_pct is not None else None
+    target_price = entry_price * (1 + take_profit_pct) if take_profit_pct is not None else None
+    peak_price = entry_price
+    bars_held = 0
+
+    for idx in range(entry_index + 1, len(closes)):
+        high = highs[idx]
+        low = lows[idx]
+        close = closes[idx]
+        if any(math.isnan(value) or value <= 0 for value in (high, low, close)):
+            continue
+
+        bars_held += 1
+        peak_price = max(peak_price, high)
+
+        stop_candidates: List[float] = []
+        if stop_price is not None:
+            stop_candidates.append(stop_price)
+        if trailing_stop_pct is not None:
+            trailing_level = peak_price * (1 - trailing_stop_pct)
+            stop_candidates.append(trailing_level)
+        effective_stop = max(stop_candidates) if stop_candidates else None
+
+        if effective_stop is not None and low <= effective_stop:
+            return effective_stop, idx, bars_held, "stop"
+        if target_price is not None and high >= target_price:
+            return target_price, idx, bars_held, "target"
+
+    final_close = closes[-1]
+    if math.isnan(final_close) or final_close <= 0:
+        final_close = entry_price
+    if bars_held == 0:
+        bars_held = 1
+    return final_close, len(closes) - 1, bars_held, "time"
+
+
+def run_backtest_scenario(
+    predictions: Sequence[int],
+    dataset: Dataset,
+    starting_cash: float,
+    stop_loss_pct: float | None,
+    take_profit_pct: float | None,
+    trailing_stop_pct: float | None,
+) -> BacktestReport:
+    cash = starting_cash
+    trades = wins = losses = 0
+    total_bars = 0
+    max_bars = 0
+    idx = 0
+    row_indices = dataset.row_indices
+
+    while idx < len(predictions):
+        if predictions[idx] != 1:
+            idx += 1
+            continue
+
+        entry_row = row_indices[idx]
+        if entry_row >= len(dataset.closes) - 1:
+            break
+        entry_price = dataset.entry_prices[idx]
+        if entry_price <= 0 or math.isnan(entry_price):
+            idx += 1
+            continue
+        if cash <= 0:
+            break
+
+        position_value = cash
+        shares = position_value / entry_price
+        cash = 0.0
+        exit_price, exit_row, bars_held, _ = simulate_trade_exit(
+            dataset.closes,
+            dataset.highs,
+            dataset.lows,
+            entry_row,
+            stop_loss_pct,
+            take_profit_pct,
+            trailing_stop_pct,
+        )
+        proceeds = shares * exit_price
+        pnl = proceeds - position_value
+        cash = proceeds
+
+        trades += 1
+        if pnl > 1e-9:
+            wins += 1
+        elif pnl < -1e-9:
+            losses += 1
+
+        total_bars += bars_held
+        max_bars = max(max_bars, bars_held)
+
+        idx += 1
+        while idx < len(predictions) and row_indices[idx] <= exit_row:
+            idx += 1
+
+    ending_value = cash
+    profit = ending_value - starting_cash
+    return_pct = (profit / starting_cash) * 100 if starting_cash else 0.0
+    win_rate = (wins / trades) * 100 if trades else 0.0
+    win_loss_ratio = (wins / losses) if losses else (float("inf") if wins > 0 else None)
+    average_bars = (total_bars / trades) if trades else 0.0
+
+    return BacktestReport(
+        starting_cash=starting_cash,
+        ending_value=ending_value,
+        trades=trades,
+        wins=wins,
+        losses=losses,
+        win_rate=win_rate,
+        win_loss_ratio=win_loss_ratio,
+        profit=profit,
+        return_pct=return_pct,
+        average_bars_held=average_bars,
+        max_bars_held=max_bars,
+        stop_loss_pct=(stop_loss_pct * 100 if stop_loss_pct is not None else None),
+        take_profit_pct=(take_profit_pct * 100 if take_profit_pct is not None else None),
+        trailing_stop_pct=(trailing_stop_pct * 100 if trailing_stop_pct is not None else None),
+    )
+
+
+def scan_backtest_scenarios(
+    predictions: Sequence[int],
+    dataset: Dataset,
+    starting_cash: float,
+    stop_losses: Sequence[float],
+    take_profits: Sequence[float],
+    trailing_stops: Sequence[float],
+    *,
+    risk_reward: float | None,
+    ratio_tolerance: float,
+    min_win_rate: float,
+) -> List[BacktestReport]:
+    results: List[BacktestReport] = []
+    trailing_options: List[float | None] = [None]
+    trailing_options.extend(trailing_stops)
+
+    for stop_loss in stop_losses:
+        for take_profit in take_profits:
+            if (
+                risk_reward is not None
+                and stop_loss
+                and take_profit
+                and stop_loss > 0
+            ):
+                ratio = take_profit / stop_loss
+                allowed_deviation = abs(risk_reward) * ratio_tolerance
+                if abs(ratio - risk_reward) > allowed_deviation:
+                    continue
+            for trailing in trailing_options:
+                report = run_backtest_scenario(
+                    predictions=predictions,
+                    dataset=dataset,
+                    starting_cash=starting_cash,
+                    stop_loss_pct=stop_loss,
+                    take_profit_pct=take_profit,
+                    trailing_stop_pct=trailing,
+                )
+                results.append(report)
+
+    if min_win_rate > 0:
+        results = [report for report in results if report.win_rate >= min_win_rate]
+
+    results.sort(key=lambda report: report.ending_value, reverse=True)
+    return results
+
+
+def normalize_percent_list(values: Sequence[float]) -> List[float]:
+    unique: List[float] = []
+    for value in values:
+        if value not in unique:
+            unique.append(value)
+    return [max(value, 0.0) / 100.0 for value in unique]
+
+
+def describe_patterns(feature_names: Sequence[str], model: NeuralNetwork) -> List[str]:
+    weights: List[Tuple[str, float]] = []
+    for idx, name in enumerate(feature_names):
+        contribution = 0.0
+        for h in range(len(model.w2)):
+            contribution += model.w1[idx][h] * model.w2[h]
+        weights.append((name, contribution))
+    ranked = sorted(weights, key=lambda item: abs(item[1]), reverse=True)
+
+    descriptions: List[str] = []
+    for name, weight in ranked:
+        direction_phrase = "bullish continuation" if weight > 0 else "bearish continuation"
+        direction_side = "bullish" if weight > 0 else "bearish"
+        if name == "log_return_1":
+            message = (
+                f"Immediate 5-minute momentum (log_return_1) favors {direction_phrase} moves on the next bar."
+            )
+        elif name == "log_return_5":
+            message = (
+                f"A positive tilt across the past five bars (log_return_5) aligns with {direction_phrase} behavior."
+            )
+        elif name == "log_return_10":
+            message = (
+                f"Broader swing momentum over ten bars (log_return_10) points toward {direction_phrase} outcomes."
+            )
+        elif name == "body_pct":
+            message = (
+                f"Larger candle bodies relative to the open (body_pct) are linked with {direction_phrase} follow-through."
+            )
+        elif name == "range_pct":
+            message = (
+                f"Wide intrabar ranges (range_pct) correlate with {direction_phrase} on the next close."
+            )
+        elif name == "volatility_5":
+            message = (
+                f"Short-term volatility (volatility_5) signals {direction_phrase} pressure when elevated."
+            )
+        elif name == "volatility_14":
+            message = (
+                f"Sustained volatility over 14 bars (volatility_14) encourages {direction_phrase} setups."
+            )
+        elif name == "ema_fast_minus_slow":
+            message = (
+                f"The 12/26 EMA spread (ema_fast_minus_slow) implies {direction_phrase} momentum bias."
+            )
+        elif name == "macd_histogram":
+            message = (
+                f"MACD histogram thrust (macd_histogram) points toward {direction_phrase}."
+            )
+        elif name == "rsi_14":
+            message = (
+                f"Relative strength (rsi_14) skew indicates {direction_phrase} pressure after normalization."
+            )
+        elif name == "atr_pct":
+            message = (
+                f"True range as a share of price (atr_pct) maps to {direction_phrase} moves in this regime."
+            )
+        elif name == "stoch_k":
+            message = (
+                f"Stochastic %%K momentum (stoch_k) biases the model toward {direction_phrase} outcomes."
+            )
+        elif name == "stoch_d":
+            message = (
+                f"Stochastic %%D confirmation (stoch_d) leans toward {direction_phrase} resolutions."
+            )
+        elif name == "trend_vs_ema":
+            message = (
+                f"Distance from the slow EMA (trend_vs_ema) anchors {direction_phrase} expectations."
+            )
+        else:
+            message = f"Feature {name} weight {weight:+.4f} indicates {direction_side} momentum."
+        descriptions.append(f"{message} (weight={weight:+.4f})")
+    return descriptions
+
+
+def run_training(
+    *,
+    data: Path,
+    train_ratio: float,
+    learning_rate: float,
+    epochs: int,
+    hidden_units: int,
+    batch_size: int,
+    train_window: int,
+    l2: float,
+    patience: int,
+    min_delta: float,
+    threshold: float,
+) -> Tuple[TrainingResult, TrainTestSplit]:
+    rows = load_dataset(data)
+    dataset = build_features(rows)
+    train, test = split_dataset(dataset, train_ratio)
+
+    standardization = compute_standardization(train.features)
+    train_scaled = apply_standardization(train.features, standardization)
+    test_scaled = apply_standardization(test.features, standardization)
+
+    if train_window > 0 and len(train_scaled) > train_window:
+        train_subset_features = train_scaled[-train_window:]
+        train_subset_targets = train.targets[-train_window:]
+    else:
+        train_subset_features = train_scaled
+        train_subset_targets = train.targets
+
+    model, loss_history = train_neural_network(
+        train_subset_features,
+        train_subset_targets,
+        learning_rate=learning_rate,
+        epochs=epochs,
+        hidden_units=hidden_units,
+        batch_size=batch_size,
+        l2=l2,
+        early_stop_patience=patience,
+        early_stop_delta=min_delta,
+    )
+
+    evaluation = evaluate_model(model, test_scaled, test.targets, threshold=threshold)
+    test_probabilities = [model.predict_proba(row) for row in test_scaled]
+    test_predictions = [1 if prob >= threshold else 0 for prob in test_probabilities]
+    result = TrainingResult(
+        model=model,
+        standardization=standardization,
+        evaluation=evaluation,
+        train_count=len(train_subset_targets),
+        full_train_count=len(train.features),
+        test_count=len(test.features),
+        test_probabilities=test_probabilities,
+        test_predictions=test_predictions,
+        threshold=threshold,
+        loss_history=loss_history,
+    )
+    split = TrainTestSplit(train=train, test=test)
+    return result, split
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data",
+        type=Path,
+        default=DATA_FILE,
+        help="Path to the OHLC CSV dataset (default: BATS_CSCO, 5.csv)",
+    )
+    parser.add_argument(
+        "--train-ratio",
+        type=float,
+        default=0.7,
+        help="Fraction of samples used for training (default: 0.7)",
+    )
+    parser.add_argument(
+        "--learning-rate",
+        type=float,
+        default=0.01,
+        help="Learning rate for neural network training (default: 0.01)",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=35,
+        help="Maximum number of training epochs (default: 35)",
+    )
+    parser.add_argument(
+        "--hidden-units",
+        type=int,
+        default=12,
+        help="Width of the neural network hidden layer (default: 12)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=512,
+        help="Mini-batch size for stochastic gradient descent (default: 512)",
+    )
+    parser.add_argument(
+        "--patience",
+        type=int,
+        default=10,
+        help="Number of epochs with minimal loss change before early stopping (default: 10; 0 disables)",
+    )
+    parser.add_argument(
+        "--min-delta",
+        type=float,
+        default=1e-4,
+        help="Minimum loss improvement required across the patience window (default: 1e-4)",
+    )
+    parser.add_argument(
+        "--train-window",
+        type=int,
+        default=2500,
+        help="Most recent training samples to fit (default: 2500; 0 uses the entire train split)",
+    )
+    parser.add_argument(
+        "--l2",
+        type=float,
+        default=0.0005,
+        help="L2 regularization strength (default: 0.0005)",
+    )
+    parser.add_argument(
+        "--signal-threshold",
+        type=float,
+        default=0.5,
+        help="Probability threshold for issuing long signals (default: 0.5)",
+    )
+    parser.add_argument(
+        "--top-signals",
+        type=int,
+        default=0,
+        help="Optionally restrict trades to the top-N probabilities that clear the threshold (default: 0 = all)",
+    )
+    parser.add_argument(
+        "--stop-losses",
+        type=float,
+        nargs="+",
+        default=[0.2, 0.4, 0.6, 0.8, 1.0, 1.5],
+        help="Static stop-loss percentages to evaluate (default: 0.2 0.4 0.6 0.8 1.0 1.5)",
+    )
+    parser.add_argument(
+        "--take-profits",
+        type=float,
+        nargs="+",
+        default=[0.4, 0.8, 1.0, 1.2, 1.6, 2.0, 3.0, 4.0],
+        help="Profit targets (percent) to evaluate (default: 0.4 0.8 1.0 1.2 1.6 2.0 3.0 4.0)",
+    )
+    parser.add_argument(
+        "--trailing-stops",
+        type=float,
+        nargs="*",
+        default=[1.0, 2.0, 3.0],
+        help="Trailing stop percentages to pair with the static stop (default: 1 2 3; omit values to disable)",
+    )
+    parser.add_argument(
+        "--risk-reward",
+        type=float,
+        default=None,
+        help="Optional minimum take-profit / stop-loss ratio (e.g., 2 for a 1:2 risk/reward)",
+    )
+    parser.add_argument(
+        "--ratio-tolerance",
+        type=float,
+        default=0.05,
+        help="Allowable fractional deviation when enforcing the risk/reward ratio (default: 0.05)",
+    )
+    parser.add_argument(
+        "--capital",
+        type=float,
+        default=1000.0,
+        help="Starting capital for the stop-loss/target scenario backtest (default: 1000)",
+    )
+    parser.add_argument(
+        "--min-win-rate",
+        type=float,
+        default=0.0,
+        help="Minimum win rate (percentage) required for a scenario to be reported (default: 0)",
+    )
+    return parser.parse_args(argv)
+
+
+def print_report(
+    *,
+    split: TrainTestSplit,
+    result: TrainingResult,
+    backtests: Sequence[BacktestReport],
+    selected_signals: int,
+) -> None:
+    train_size = result.train_count
+    test_size = result.test_count
+    print("Advanced machine learning pattern discovery for CSCO 5-minute data")
+    print("=================================================================")
+    print(
+        f"Samples (train/test): {train_size} / {test_size} "
+        f"(from {result.full_train_count} total train bars)"
+    )
+    hidden_units = len(result.model.w2)
+    print(
+        f"Architecture: {len(split.train.feature_names)} inputs -> {hidden_units} hidden -> 1 output"
+    )
+    print(f"Signal probability threshold: {result.threshold:.2f}")
+    print(f"Signals passing threshold : {selected_signals}")
+    print("Features: " + ", ".join(split.train.feature_names))
+    print("")
+    print("Test set evaluation:")
+    eval_result = result.evaluation
+    print(f"  Accuracy : {eval_result.accuracy:.4f}")
+    print(f"  Precision: {eval_result.precision:.4f}")
+    print(f"  Recall   : {eval_result.recall:.4f}")
+    print(f"  F1 score : {eval_result.f1:.4f}")
+    print(f"  Confusion matrix (TP, TN, FP, FN): {eval_result.true_positive}, {eval_result.true_negative}, {eval_result.false_positive}, {eval_result.false_negative}")
+    if result.loss_history:
+        print(f"  Epochs trained : {len(result.loss_history)}")
+        print(f"  Final training loss: {result.loss_history[-1]:.4f}")
+    print("")
+    print("Feature influence (highest magnitude first):")
+    descriptions = describe_patterns(split.train.feature_names, result.model)
+    for line in descriptions:
+        print("  - " + line)
+    print("")
+    print("Stop-loss / target scan on the test set:")
+    if not backtests:
+        print("  No qualifying trade scenarios matched the filters.")
+        return
+
+    best = backtests[0]
+
+    def format_ratio(value: float | None) -> str:
+        if value is None:
+            return "n/a"
+        if math.isinf(value):
+            return "Infinity"
+        return f"{value:.2f}"
+
+    def format_percent(value: float | None) -> str:
+        if value is None:
+            return "-"
+        return f"{value:.2f}"
+
+    print(f"  Scenarios evaluated : {len(backtests)}")
+    print(
+        f"  Best ending equity  : ${best.ending_value:,.2f} "
+        f"(profit ${best.profit:,.2f}, {best.return_pct:.2f}%)"
+    )
+    print(
+        "  Parameters          : "
+        f"stop {format_percent(best.stop_loss_pct)}% / "
+        f"target {format_percent(best.take_profit_pct)}% / "
+        f"trailing {format_percent(best.trailing_stop_pct)}%"
+    )
+    print(
+        f"  Trades / Wins / Losses : {best.trades} / {best.wins} / {best.losses}"
+    )
+    print(f"  Win rate            : {best.win_rate:.2f}%")
+    print(f"  Win/loss ratio      : {format_ratio(best.win_loss_ratio)}")
+    print(
+        f"  Avg hold (bars)     : {best.average_bars_held:.2f} "
+        f"(max {best.max_bars_held})"
+    )
+
+    print("")
+    print("  Top scenarios by ending equity:")
+    header = (
+        f"{'Stop%':>7} {'Target%':>8} {'Trail%':>7} "
+        f"{'End Equity':>14} {'Return%':>9} {'Trades':>8} "
+        f"{'Win%':>7} {'AvgBars':>8}"
+    )
+    print("  " + header)
+    for report in backtests[:5]:
+        print(
+            "  "
+            f"{format_percent(report.stop_loss_pct):>7} "
+            f"{format_percent(report.take_profit_pct):>8} "
+            f"{format_percent(report.trailing_stop_pct):>7} "
+            f"{report.ending_value:>14,.2f} "
+            f"{report.return_pct:>9.2f} "
+            f"{report.trades:>8} "
+            f"{report.win_rate:>7.2f} "
+            f"{report.average_bars_held:>8.2f}"
+        )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    result, split = run_training(
+        data=args.data,
+        train_ratio=args.train_ratio,
+        learning_rate=args.learning_rate,
+        epochs=args.epochs,
+        hidden_units=args.hidden_units,
+        batch_size=args.batch_size,
+        train_window=args.train_window,
+        l2=args.l2,
+        patience=args.patience,
+        min_delta=args.min_delta,
+        threshold=args.signal_threshold,
+    )
+    stop_losses = normalize_percent_list(args.stop_losses)
+    take_profits = normalize_percent_list(args.take_profits)
+    trailing_stops = normalize_percent_list(args.trailing_stops)
+
+    if not stop_losses:
+        raise ValueError("Provide at least one stop-loss percentage")
+    if not take_profits:
+        raise ValueError("Provide at least one take-profit percentage")
+
+    eligible = [
+        (prob, idx)
+        for idx, prob in enumerate(result.test_probabilities)
+        if prob >= args.signal_threshold
+    ]
+    if args.top_signals > 0 and len(eligible) > args.top_signals:
+        eligible.sort(key=lambda item: item[0], reverse=True)
+        selected_indices = {idx for _, idx in eligible[: args.top_signals]}
+    else:
+        selected_indices = {idx for _, idx in eligible}
+    signal_predictions = [1 if idx in selected_indices else 0 for idx in range(len(result.test_probabilities))]
+    backtests = scan_backtest_scenarios(
+        predictions=signal_predictions,
+        dataset=split.test,
+        starting_cash=args.capital,
+        stop_losses=stop_losses,
+        take_profits=take_profits,
+        trailing_stops=trailing_stops,
+        risk_reward=args.risk_reward,
+        ratio_tolerance=args.ratio_tolerance,
+        min_win_rate=args.min_win_rate,
+    )
+    print_report(
+        split=split,
+        result=result,
+        backtests=backtests,
+        selected_signals=len(selected_indices),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/renko_brick_optimizer.py
+++ b/renko_brick_optimizer.py
@@ -1,0 +1,266 @@
+"""Evaluate optimal Renko brick size for 5-minute closing prices.
+
+This module reads intraday OHLC data (specifically the close column) and
+constructs Renko charts for a sweep of candidate brick sizes. Each candidate is
+scored using a simple trend persistence heuristic that rewards brick sizes which
+produce numerous bricks while also minimizing noisy back-and-forth reversals.
+
+Example
+-------
+$ python renko_brick_optimizer.py --data 'BATS_CSCO, 5.csv'
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass
+class RenkoBrickStats:
+    """Summary metrics for a single Renko brick size."""
+
+    brick_size: float
+    brick_count: int
+    reversal_count: int
+    trending_ratio: float
+    total_move: float
+    net_move: float
+    score: float
+
+def build_renko_bricks(prices: Iterable[float], brick_size: float) -> List[float]:
+    """Construct Renko bricks from a sequence of prices.
+
+    Parameters
+    ----------
+    prices:
+        Iterable of closing prices.
+    brick_size:
+        Positive float representing the price move required to form a brick.
+
+    Returns
+    -------
+    List[float]
+        A list containing the signed direction of each Renko brick (+1 or -1).
+    """
+
+    if brick_size <= 0:
+        raise ValueError("brick_size must be positive")
+
+    iterator = iter(prices)
+    try:
+        last_close = float(next(iterator))
+    except StopIteration:
+        return []
+
+    brick_directions: List[float] = []
+    last_brick_close = last_close
+
+    for price in iterator:
+        price = float(price)
+        delta = price - last_brick_close
+
+        while delta >= brick_size:
+            last_brick_close += brick_size
+            brick_directions.append(1.0)
+            delta -= brick_size
+
+        while delta <= -brick_size:
+            last_brick_close -= brick_size
+            brick_directions.append(-1.0)
+            delta += brick_size
+
+    return brick_directions
+
+
+def score_brick_size(prices: Iterable[float], brick_size: float) -> RenkoBrickStats:
+    """Compute summary statistics for a Renko brick size."""
+
+    bricks = build_renko_bricks(prices, brick_size)
+    brick_count = len(bricks)
+
+    if brick_count == 0:
+        return RenkoBrickStats(
+            brick_size=brick_size,
+            brick_count=0,
+            reversal_count=0,
+            trending_ratio=0.0,
+            total_move=0.0,
+            net_move=0.0,
+            score=0.0,
+        )
+
+    reversal_count = sum(
+        1 for prev, curr in zip(bricks[:-1], bricks[1:]) if curr != prev
+    )
+
+    trending_ratio = 1.0
+    if brick_count > 1:
+        trending_ratio = 1.0 - (reversal_count / (brick_count - 1))
+
+    total_move = brick_count * brick_size
+    net_move = sum(bricks) * brick_size
+    score = trending_ratio * total_move
+
+    return RenkoBrickStats(
+        brick_size=brick_size,
+        brick_count=brick_count,
+        reversal_count=reversal_count,
+        trending_ratio=trending_ratio,
+        total_move=total_move,
+        net_move=net_move,
+        score=score,
+    )
+
+
+def generate_candidate_bricks(
+    closes: List[float],
+    min_brick: float | None,
+    max_brick: float | None,
+    steps: int,
+) -> List[float]:
+    """Create a range of candidate brick sizes."""
+
+    price_range = max(closes) - min(closes)
+    if price_range <= 0:
+        raise ValueError("Closing prices must span a non-zero range")
+
+    if min_brick is None:
+        min_brick = price_range / 200.0
+
+    if max_brick is None:
+        max_brick = price_range / 10.0
+
+    if min_brick <= 0 or max_brick <= 0:
+        raise ValueError("Brick sizes must be positive")
+
+    if min_brick >= max_brick:
+        raise ValueError("min_brick must be smaller than max_brick")
+
+    if steps < 2:
+        raise ValueError("steps must be at least 2")
+
+    step = (max_brick - min_brick) / (steps - 1)
+    return [min_brick + i * step for i in range(steps)]
+
+
+def load_closing_prices(path: str) -> List[float]:
+    """Load closing prices from the provided CSV file."""
+
+    with open(path, newline="") as csvfile:
+        reader = csv.DictReader(csvfile)
+
+        if reader.fieldnames is None:
+            raise ValueError("CSV file is missing a header row")
+
+        normalized = {name.strip().lower(): name for name in reader.fieldnames}
+
+        close_col_name = None
+        for candidate in ("close", "closing"):
+            if candidate in normalized:
+                close_col_name = normalized[candidate]
+                break
+
+        if close_col_name is None:
+            raise KeyError(
+                "Unable to find a closing price column. Expected one named 'close' or 'closing'."
+            )
+
+        closes: List[float] = []
+        for row in reader:
+            raw_value = row.get(close_col_name)
+            if raw_value is None:
+                continue
+
+            try:
+                closes.append(float(raw_value))
+            except (TypeError, ValueError):
+                continue
+
+    if not closes:
+        raise ValueError("No valid closing prices found in the dataset")
+
+    return closes
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate Renko brick sizes for 5-minute closing data",
+    )
+    parser.add_argument(
+        "--data",
+        required=True,
+        help="Path to the CSV file containing 5-minute OHLC data",
+    )
+    parser.add_argument(
+        "--min-brick",
+        type=float,
+        default=None,
+        help="Minimum brick size to evaluate. Defaults to price_range / 200.",
+    )
+    parser.add_argument(
+        "--max-brick",
+        type=float,
+        default=None,
+        help="Maximum brick size to evaluate. Defaults to price_range / 10.",
+    )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=25,
+        help="Number of brick sizes to evaluate between min and max (inclusive).",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=5,
+        help="Number of top-performing brick sizes to display.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    closes = load_closing_prices(args.data)
+    candidates = generate_candidate_bricks(closes, args.min_brick, args.max_brick, args.steps)
+
+    stats: List[RenkoBrickStats] = [
+        score_brick_size(closes, float(brick_size)) for brick_size in candidates
+    ]
+
+    stats.sort(key=lambda item: item.score, reverse=True)
+
+    top_n = stats[: max(1, min(args.top, len(stats)))]
+
+    header = (
+        f"{'brick_size':>12}  {'bricks':>8}  {'reversals':>10}  "
+        f"{'trend_ratio':>12}  {'total_move':>12}  {'net_move':>10}  {'score':>12}"
+    )
+    print("Top brick sizes by Renko trend score:\n")
+    print(header)
+    print("-" * len(header))
+    for stat in top_n:
+        print(
+            f"{stat.brick_size:12.6f}  "
+            f"{stat.brick_count:8d}  "
+            f"{stat.reversal_count:10d}  "
+            f"{stat.trending_ratio:12.6f}  "
+            f"{stat.total_move:12.6f}  "
+            f"{stat.net_move:10.6f}  "
+            f"{stat.score:12.6f}"
+        )
+
+    best = stats[0]
+    print()
+    print(
+        "Suggested brick size:"
+        f" {best.brick_size:.6f} (score={best.score:.6f},"
+        f" bricks={best.brick_count},"
+        f" reversals={best.reversal_count})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/supertrend_backtest.py
+++ b/supertrend_backtest.py
@@ -1,0 +1,290 @@
+"""Backtest a Supertrend strategy on intraday OHLC data."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import dataclass
+from typing import List, Sequence
+
+
+def load_ohlc(path: str) -> tuple[List[str], List[float], List[float], List[float], List[float]]:
+    """Load timestamped OHLC data from a CSV file."""
+
+    with open(path, newline="") as csvfile:
+        reader = csv.DictReader(csvfile)
+        if reader.fieldnames is None:
+            raise ValueError("CSV file must include a header row")
+
+        normalized = {name.strip().lower(): name for name in reader.fieldnames}
+
+        required = ["time", "open", "high", "low", "close"]
+        missing = [col for col in required if col not in normalized]
+        if missing:
+            raise KeyError(f"Missing expected columns: {', '.join(missing)}")
+
+        times: List[str] = []
+        opens: List[float] = []
+        highs: List[float] = []
+        lows: List[float] = []
+        closes: List[float] = []
+
+        for row in reader:
+            try:
+                times.append(row[normalized["time"]])
+                opens.append(float(row[normalized["open"]]))
+                highs.append(float(row[normalized["high"]]))
+                lows.append(float(row[normalized["low"]]))
+                closes.append(float(row[normalized["close"]]))
+            except (TypeError, ValueError):
+                # Skip rows with malformed numeric data
+                continue
+
+    if not times:
+        raise ValueError("No valid OHLC rows were parsed from the CSV file")
+
+    return times, opens, highs, lows, closes
+
+
+def compute_atr(highs: Sequence[float], lows: Sequence[float], closes: Sequence[float], period: int) -> List[float | None]:
+    """Calculate the Average True Range (ATR) using Wilder's smoothing."""
+
+    if period <= 0:
+        raise ValueError("ATR period must be positive")
+
+    tr_values: List[float] = []
+    for idx, (high, low) in enumerate(zip(highs, lows)):
+        if idx == 0:
+            tr_values.append(high - low)
+            continue
+        prev_close = closes[idx - 1]
+        tr = max(high - low, abs(high - prev_close), abs(low - prev_close))
+        tr_values.append(tr)
+
+    atr: List[float | None] = [None] * len(tr_values)
+    if len(tr_values) < period:
+        return atr
+
+    initial_atr = sum(tr_values[:period]) / period
+    atr[period - 1] = initial_atr
+
+    for idx in range(period, len(tr_values)):
+        prev_atr = atr[idx - 1]
+        if prev_atr is None:
+            raise RuntimeError("Unexpected None ATR value during smoothing")
+        atr[idx] = (prev_atr * (period - 1) + tr_values[idx]) / period
+
+    return atr
+
+
+@dataclass
+class SupertrendPoint:
+    timestamp: str
+    close: float
+    supertrend: float
+    trend: int  # 1 for bullish, -1 for bearish
+
+
+def compute_supertrend(
+    timestamps: Sequence[str],
+    highs: Sequence[float],
+    lows: Sequence[float],
+    closes: Sequence[float],
+    period: int,
+    multiplier: float,
+) -> List[SupertrendPoint]:
+    """Compute the Supertrend indicator."""
+
+    if len(highs) != len(lows) or len(highs) != len(closes):
+        raise ValueError("High, low, and close series must be the same length")
+
+    atr = compute_atr(highs, lows, closes, period)
+    points: List[SupertrendPoint] = []
+
+    final_upper: List[float | None] = [None] * len(highs)
+    final_lower: List[float | None] = [None] * len(highs)
+    supertrend: List[float | None] = [None] * len(highs)
+    trend_dir: List[int | None] = [None] * len(highs)
+
+    for idx in range(len(highs)):
+        atr_value = atr[idx]
+        if atr_value is None:
+            continue
+
+        hl2 = (highs[idx] + lows[idx]) / 2.0
+        basic_upper = hl2 + multiplier * atr_value
+        basic_lower = hl2 - multiplier * atr_value
+
+        if idx == 0 or final_upper[idx - 1] is None:
+            final_upper[idx] = basic_upper
+            final_lower[idx] = basic_lower
+        else:
+            prev_final_upper = final_upper[idx - 1]
+            prev_final_lower = final_lower[idx - 1]
+            prev_close = closes[idx - 1]
+
+            assert prev_final_upper is not None and prev_final_lower is not None
+
+            final_upper[idx] = (
+                basic_upper
+                if basic_upper < prev_final_upper or prev_close > prev_final_upper
+                else prev_final_upper
+            )
+            final_lower[idx] = (
+                basic_lower
+                if basic_lower > prev_final_lower or prev_close < prev_final_lower
+                else prev_final_lower
+            )
+
+        if idx == 0 or supertrend[idx - 1] is None:
+            if closes[idx] <= final_upper[idx]:
+                supertrend[idx] = final_upper[idx]
+                trend_dir[idx] = -1
+            else:
+                supertrend[idx] = final_lower[idx]
+                trend_dir[idx] = 1
+        else:
+            prev_supertrend = supertrend[idx - 1]
+            prev_trend = trend_dir[idx - 1]
+            assert prev_supertrend is not None and prev_trend is not None
+
+            if prev_trend == -1:
+                if closes[idx] <= final_upper[idx]:
+                    supertrend[idx] = final_upper[idx]
+                    trend_dir[idx] = -1
+                else:
+                    supertrend[idx] = final_lower[idx]
+                    trend_dir[idx] = 1
+            else:
+                if closes[idx] >= final_lower[idx]:
+                    supertrend[idx] = final_lower[idx]
+                    trend_dir[idx] = 1
+                else:
+                    supertrend[idx] = final_upper[idx]
+                    trend_dir[idx] = -1
+
+        points.append(
+            SupertrendPoint(
+                timestamp=timestamps[idx],
+                close=closes[idx],
+                supertrend=supertrend[idx],
+                trend=trend_dir[idx],
+            )
+        )
+
+    return points
+
+
+@dataclass
+class BacktestResult:
+    initial_capital: float
+    final_capital: float
+    net_profit: float
+    net_return_pct: float
+    total_trades: int
+    buy_and_hold_return_pct: float
+
+
+def run_backtest(points: Sequence[SupertrendPoint], initial_capital: float) -> BacktestResult:
+    """Execute a simple Supertrend crossover backtest."""
+
+    cash = initial_capital
+    position = 0.0  # number of shares
+    total_trades = 0
+    prev_trend = None
+
+    closes = [pt.close for pt in points]
+    if not closes:
+        raise ValueError("Supertrend series is empty")
+
+    for point in points:
+        if point.trend is None:
+            continue
+
+        if prev_trend is None:
+            prev_trend = point.trend
+            continue
+
+        # Trend flip from bearish to bullish -> buy
+        if prev_trend == -1 and point.trend == 1 and position == 0.0:
+            price = point.close
+            if price <= 0:
+                prev_trend = point.trend
+                continue
+            position = cash / price
+            cash = 0.0
+            total_trades += 1
+        # Trend flip from bullish to bearish -> sell
+        elif prev_trend == 1 and point.trend == -1 and position > 0.0:
+            cash = position * point.close
+            position = 0.0
+            total_trades += 1
+
+        prev_trend = point.trend
+
+    final_value = cash + position * closes[-1]
+    net_profit = final_value - initial_capital
+    net_return_pct = (net_profit / initial_capital) * 100.0
+
+    buy_and_hold_return_pct = ((closes[-1] - closes[0]) / closes[0]) * 100.0
+
+    return BacktestResult(
+        initial_capital=initial_capital,
+        final_capital=final_value,
+        net_profit=net_profit,
+        net_return_pct=net_return_pct,
+        total_trades=total_trades,
+        buy_and_hold_return_pct=buy_and_hold_return_pct,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Supertrend backtest for OHLC data")
+    parser.add_argument("--data", required=True, help="Path to the CSV file with OHLC data")
+    parser.add_argument("--period", type=int, default=10, help="Supertrend ATR period (default: 10)")
+    parser.add_argument(
+        "--multiplier",
+        type=float,
+        default=1.5,
+        help="Supertrend ATR multiplier (default: 1.5)",
+    )
+    parser.add_argument(
+        "--capital",
+        type=float,
+        default=1000.0,
+        help="Initial capital for the backtest (default: 1000)",
+    )
+    return parser.parse_args()
+
+
+def format_currency(value: float) -> str:
+    return f"$ {value:,.2f}"
+
+
+def main() -> None:
+    args = parse_args()
+    timestamps, opens, highs, lows, closes = load_ohlc(args.data)
+    supertrend_points = compute_supertrend(
+        timestamps,
+        highs,
+        lows,
+        closes,
+        period=args.period,
+        multiplier=args.multiplier,
+    )
+    result = run_backtest(supertrend_points, args.capital)
+
+    print("Supertrend Backtest Summary\n")
+    print(f"Data file: {args.data}")
+    print(f"Period: {args.period}")
+    print(f"Multiplier: {args.multiplier}")
+    print(f"Initial capital: {format_currency(result.initial_capital)}")
+    print(f"Final capital:   {format_currency(result.final_capital)}")
+    print(f"Net profit:      {format_currency(result.net_profit)}")
+    print(f"Return:          {result.net_return_pct:.2f}%")
+    print(f"Buy & Hold:      {result.buy_and_hold_return_pct:.2f}%")
+    print(f"Total trades:    {result.total_trades}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add threshold-aware evaluation and a top-signal selector so only the highest-confidence predictions drive the stop/target scan
- extend the scenario grid with risk-reward filtering, win-rate floors, and expanded stop/target defaults, reporting the number of qualified signals
- document the new levers in the README for configuring signal thresholds, top-N selection, win-rate minima, and risk/reward guards

## Testing
- python machine_learning_patterns.py --data 'BATS_CSCO, 5.csv' --capital 1000 --risk-reward 2 --min-win-rate 50 --top-signals 25


------
https://chatgpt.com/codex/tasks/task_e_68f447e9bbf483228a3729591ead82b0